### PR TITLE
Fix #1: remove resync feature to prevent unlimited EXP exploit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -642,24 +642,6 @@ export function App() {
     };
   }, [stdout]);
 
-  // Resync handler
-  const handleResync = useCallback(async () => {
-    try {
-      const result = await scanClaudeActivity(0);
-      dispatch({
-        type: "SYNC_STATS",
-        stats: {
-          totalConversations: result.totalConversations,
-          totalToolUses: result.totalToolUses,
-          totalMessages: result.totalMessages,
-        },
-        expGained: result.expGained,
-        offset: result.newOffset,
-      });
-    } catch {
-      dispatch({ type: "SET_NOTIFICATION", message: "Resync failed" });
-    }
-  }, []);
 
   // Keyboard
   useInput((input, key) => {
@@ -692,10 +674,6 @@ export function App() {
       if (input === "t" || input === "T") {
         process.stdout.write("\x1b[2J\x1b[H");
         dispatch({ type: "SET_VIEW", view: "stats" });
-        return;
-      }
-      if (input === "r" || input === "R") {
-        handleResync();
         return;
       }
     } else {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -83,8 +83,6 @@ export function StatusBar({ state, view, notification, width }: StatusBarProps) 
               <Text>nfo </Text>
               <Text color="yellowBright">[D]</Text>
               <Text>eco </Text>
-              <Text color="yellowBright">[R]</Text>
-              <Text>esync </Text>
               <Text color="yellowBright">[Q]</Text>
               <Text>uit</Text>
             </Text>

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -435,12 +435,6 @@ export function renderStatusToAnsi(
         "stats " +
         RESET +
         (ANSI_COLORS["yellowBright"] ?? "") +
-        "[R]" +
-        RESET +
-        (ANSI_COLORS["white"] ?? "") +
-        "esync " +
-        RESET +
-        (ANSI_COLORS["yellowBright"] ?? "") +
         "[Q]" +
         RESET +
         (ANSI_COLORS["white"] ?? "") +


### PR DESCRIPTION
  ## Summary
  - Remove the manual resync (R key) feature which allowed unlimited EXP by re-scanning all session files from offset 0 on every press
  - Remove `handleResync` callback and R key handler from `App.tsx`
  - Remove `[R]esync` UI hints from both StatusBar (Ink) and renderer (ANSI)
  - EXP is now exclusively managed by the file watcher and 5s polling, both offset-guarded

  Closes #1

  ## Test plan
  - [x] Verify R key no longer triggers any action in aquarium view
  - [x] Verify EXP still increments from real Claude Code activity (file watcher + polling)
  - [x] Verify `[R]esync` no longer appears in the status bar